### PR TITLE
Fix typo in class name

### DIFF
--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -33,7 +33,7 @@ class CsobClient(object):
         self.f_key = private_key_file
         self.f_pubkey = csob_pub_key_file
 
-        session = utils.PyscobSession()
+        session = utils.PycsobSession()
         session.headers = conf.HEADERS
         session.mount('https://', HTTPAdapter())
         session.mount('http://', HTTPAdapter())

--- a/pycsob/utils.py
+++ b/pycsob/utils.py
@@ -19,7 +19,7 @@ class CsobVerifyError(Exception):
     pass
 
 
-class PyscobSession(requests.Session):
+class PycsobSession(requests.Session):
     """Request session with logging requests."""
 
     def post(self, url, data=None, json=None, **kwargs):


### PR DESCRIPTION
'PyscobSession' -> 'PycsobSession' (as CSOB is the bank name)