### PR TITLE
Add custom payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Logging requests and responses.
+- Support for _custom payments_.
 
 ### Changed
 - Upgrade the current code to the [Basic-Payment] version 1.9.

--- a/README.rst
+++ b/README.rst
@@ -36,12 +36,13 @@ eAPI-v1.9 Wiki
 
 https://github.com/csob/paymentgateway/wiki/eAPI-v1.9
 
-Caution! This module implements only `Basic Payment <https://github.com/csob/paymentgateway/wiki/Basic-Payment>`_ and
+Caution! This module implements only `Basic Payment <https://github.com/csob/paymentgateway/wiki/Basic-Payment>`_,
+`Custom Payment <https://github.com/csob/paymentgateway/wiki/Custom-Payment>`_ and
 `Methods for ČSOB Payment Button <https://github.com/csob/paymentgateway/wiki/Methods-for-%C4%8CSOB-Payment-Button>`_ from API v1.9.
 
 Basic usage:
 ------------
-
+ 
 .. code-block:: python
 
     from pycsob.client import CsobClient
@@ -61,11 +62,10 @@ like ``payload`` or ``extensions``.
     #[Out]#              ('dttm', '20160615104254'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 1)]),
-    #[Out]#              ('merchantData', [1, 2, 3])]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54)),
+    #[Out]#              ('paymentStatus', 1),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54))])
 
-After payment init get URL to redirect to for payId obtained from previous step.
+After payment init get URL to redirect to for ``payId`` obtained from previous step.
 
 .. code-block:: python
 
@@ -83,8 +83,28 @@ You can check payment status.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
-    #[Out]#              ('authCode', '042760')]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 1)),
+    #[Out]#              ('authCode', '042760'),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 1))])
+
+Custom payments are initialized with ``c.payment_init(pay_operation='customPayment')``, you can optionally set 
+payment validity by ``custom_expiry='YYYYMMDDhhmmss'``.
+
+.. code-block:: python
+
+    r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Testovaci nakup', return_method='POST',
+                       pay_operation='customPayment', custom_expiry='20160630120000')
+    r.payload
+    #[Out]# OrderedDict([('payId', 'b627c1e4e60fcBF'),
+    #[Out]#              ('dttm', '20160615104254'),
+    #[Out]#              ('resultCode', 0),
+    #[Out]#              ('resultMessage', 'OK'),
+    #[Out]#              ('paymentStatus', 1)]),
+    #[Out]#              ('customerCode', 'E61EC8'),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54))])
+
+Send (by whatever means) obtained ``customerCode`` to customer who can then perform payment anytime within its validity
+on URL ``https://platebnibrana.csob.cz/payment/{customerCode}`` (``c.get_payment_process_url`` is not applicable
+for custom payments).
 
 You can also use one-click payment methods. For this you need
 to call ``c.payment_init(pay_operation='oneclickPayment')``. After this transaction confirmed
@@ -98,8 +118,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('dttm', '20160615104532'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 1)]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32)),
+    #[Out]#              ('paymentStatus', 1),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32))])
 
     r = c.oneclick_start('ff7d3e7c6c4fdBF')
     r.payload
@@ -107,8 +127,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('dttm', '20160615104619'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 2)]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19)),
+    #[Out]#              ('paymentStatus', 2),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19))])
 
     r = c.payment_status('ff7d3e7c6c4fdBF')
     r.payload
@@ -117,8 +137,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
-    #[Out]#              ('authCode', '168164')]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43)),
+    #[Out]#              ('authCode', '168164'),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43))])
 
 Of course you can use standard requests's methods on ``response`` object.
 

--- a/pycsob/__init__.py
+++ b/pycsob/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (1, 0, 0)
+__version__ = (1, 0, 1)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/pycsob/conf.py
+++ b/pycsob/conf.py
@@ -7,7 +7,7 @@ HEADERS = {
 }
 EMPTY_VALUES = ('', None, [], (), {})
 RESPONSE_KEYS = ('payId', 'customerId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'authCode',
-                 'merchantData')
+                 'merchantData', 'customerCode')
 
 # available languages and currencies
 LANGUAGES = 'CZ', 'EN', 'DE', 'SK', 'HU', 'IT', 'JP', 'PL', 'PT', 'RO', 'RU', 'SK', 'ES', 'TR', 'VN'

--- a/tests_pycsob/test_api.py
+++ b/tests_pycsob/test_api.py
@@ -53,7 +53,7 @@ class CsobClientTests(TestCase):
             '"C9puGaxsYLEIazy04hVtCx5sMu8/eg6F2l17UfIUgCKFP4XvHIYA3xbIplbv1HbbQlGKgmw3FhD+FEYwq/E0bg=="}; '
             'Json: None; {}'), (
             'pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '157'}"), (
+            "'py-csob/1.0.1', 'Content-Length': '157'}"), (
             'pycsob', 'INFO', 'Pycsob response: [200] {"dttm": "20190502161426", "resultCode": 0, '
             '"resultMessage": "OK", "signature": '
             '"hEyfa8OBR+eQIeqxBFB1SA9SHdhNkKBlM37IEizZ6z+2Bb4VSu1qldcpJEzARHOHJAgUOmwVXZC9v0MYcMg0TQ=="}'), (
@@ -83,7 +83,7 @@ class CsobClientTests(TestCase):
             'https://gw.cz/echo/MERCHANT/20190502161426/C9puGaxsYLEIazy04hVtCx5sMu8%2Feg6F2l17UfIUgCKFP4XvHIYA3xbIplbv'
             '1HbbQlGKgmw3FhD%2BFEYwq%2FE0bg%3D%3D; {}'), (
             'pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0'}"), (
+            "'py-csob/1.0.1'}"), (
             'pycsob', 'INFO', 'Pycsob response: [200] {"dttm": "20190502161426", "resultCode": 0, '
             '"resultMessage": "OK", "signature": '
             '"hEyfa8OBR+eQIeqxBFB1SA9SHdhNkKBlM37IEizZ6z+2Bb4VSu1qldcpJEzARHOHJAgUOmwVXZC9v0MYcMg0TQ=="}'), (
@@ -128,7 +128,7 @@ class CsobClientTests(TestCase):
             '"KMLqDJs+vSFqLaEG66i6MtkRZEL6U9HwqT3dPrYh237agzlkPnkXHHrCF2p+Sntzq/UWN03HfDhL5IHSsHvp6Q=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '460'}"),
+            "'py-csob/1.0.1', 'Content-Length': '460'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 0, "resultMessage": "OK", "paymentStatus": 1, "signature": '
             '"Zd+PKspUEkrsEyxTmXAwrX3pgfS45Sg35dhMo5Oi0aoI8LoLs3dlyPS9vEXw80fxKyduAl5ws8D0Fu2mXLy9bA=="}'),
@@ -172,7 +172,7 @@ class CsobClientTests(TestCase):
             '"signature": "FcfTzD5ChQXyWAgBMZX+d/QOBbaGKXRusHwpiOaX+Aticygm1D8EzH+MtnMFq+Gp3dcQMTUg0bQKaCXfcQBeiA=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '492'}"),
+            "'py-csob/1.0.1', 'Content-Length': '492'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 110, "resultMessage": "Invalid \'cart\' amounts, does not sum to totalAmount", '
             '"paymentStatus": 6, "signature": '
@@ -217,7 +217,7 @@ class CsobClientTests(TestCase):
             '26/hi0fi1sF0BL0SLWagZ9QJ4aLe7B3I0MN0rr0ocRb75ZP7wZunTLdrbFkALs1rUQYe1sJaKaoo%2B%2BoVs6grd%2F0WA%3D%3D;'
             ' {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0'}"),
+            "'py-csob/1.0.1'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 110, "resultMessage": "OK", "paymentStatus": 7, "authCode": "F7A23E", "signature": '
             '"FFXfpqhazvXVKEMckHw+Y2tRDespTUp62NQ6kAwA4T0LNT6LDKj70d5XBJrrx3XNs92JGUT6wIJZR25MFmibFA==", '
@@ -239,7 +239,7 @@ class CsobClientTests(TestCase):
             '"C9puGaxsYLEIazy04hVtCx5sMu8/eg6F2l17UfIUgCKFP4XvHIYA3xbIplbv1HbbQlGKgmw3FhD+FEYwq/E0bg=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '157'}"),
+            "'py-csob/1.0.1', 'Content-Length': '157'}"),
             ('pycsob', 'INFO', 'Pycsob response: [500] '),
             ('pycsob', 'DEBUG', "Pycsob response headers: {'Content-Type': 'text/plain'}")
         )
@@ -300,7 +300,7 @@ class CsobClientTests(TestCase):
             '"a5jKBePOpjgX0CjUkKFTe3UzedHzFgrvSsVf3NnSZ7uzuFyBIs5QEVxN9QZ8y7LKKRiigEzU8r6GZ3MiEFf9RA=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', "
-            "'user-agent': 'py-csob/1.0.0', 'Content-Length': '466'}"),
+            "'user-agent': 'py-csob/1.0.1', 'Content-Length': '466'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 0, "resultMessage": "OK", "paymentStatus": 1, "signature": '
             '"Zd+PKspUEkrsEyxTmXAwrX3pgfS45Sg35dhMo5Oi0aoI8LoLs3dlyPS9vEXw80fxKyduAl5ws8D0Fu2mXLy9bA=="}'),
@@ -349,7 +349,7 @@ class CsobClientTests(TestCase):
             '"XH4RdW0dXrDh81dUHNKMrF+LVfZZtIOKJXzVUSxB/RVKK2Sb59SJvl8jonujNZC78GJkr5THLCbnMJNUfXpQag=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '442'}"),
+            "'py-csob/1.0.1', 'Content-Length': '442'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 0, "resultMessage": "OK", "paymentStatus": 1, "signature": '
             '"Zd+PKspUEkrsEyxTmXAwrX3pgfS45Sg35dhMo5Oi0aoI8LoLs3dlyPS9vEXw80fxKyduAl5ws8D0Fu2mXLy9bA=="}'),
@@ -384,7 +384,7 @@ class CsobClientTests(TestCase):
             '"H+eKbex5KdHUtZ/fxB5vfMlgEkH3H6RfDj3oR9i/R/8HYInmyP0tz6+lqzF8EztHmpA/vxevW9qvNTgV535eZw=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '482'}"),
+            "'py-csob/1.0.1', 'Content-Length': '482'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 0, "resultMessage": "OK", "paymentStatus": 1, "customerCode": "E61EC8", "signature": '
             '"KmqB9foNOz7aJuyujNcHDpD7rmPZzkN/AePWw62h5xYxowrd1Jb5o6JdF1S76USHaPn4yc+iOIM+pw601l3PxQ=="}'),
@@ -417,7 +417,7 @@ class CsobClientTests(TestCase):
              '"D3rppiWK7zp1B9ra94cxQczOwfUVrRnyd8oLRTd4guC+qXALRXKHgqc7AVPnM3kuMG6fRY9B4X9+10n/603C9Q=="}; '
              'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-             "'py-csob/1.0.0', 'Content-Length': '345'}"),
+             "'py-csob/1.0.1', 'Content-Length': '345'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": '
              '"20190502161426", "resultCode": 0, "resultMessage": "OK", "signature": '
              '"mMvfLq/SzhagYKkJp/PnQ+Y9zoMJIGt1OznlxQLqq+gsyhOjUd4ghDtJtFt8bQkpr+jwj6kd/y8R5RyxZ7qgag=="}'),
@@ -475,7 +475,7 @@ class CsobClientTests(TestCase):
             '"Zd+PKspUEkrsEyxTmXAwrX3pgfS45Sg35dhMo5Oi0aoI8LoLs3dlyPS9vEXw80fxKyduAl5ws8D0Fu2mXLy9bA=="}; '
             'Json: None; {}'),
             ('pycsob', 'DEBUG', "Pycsob request headers: {'content-type': 'application/json', 'user-agent': "
-            "'py-csob/1.0.0', 'Content-Length': '219'}"),
+            "'py-csob/1.0.1', 'Content-Length': '219'}"),
             ('pycsob', 'INFO', 'Pycsob response: [200] {"payId": "34ae55eb69e2cBF", "dttm": "20190502161426", '
             '"resultCode": 0, "resultMessage": "OK", "paymentStatus": 1, "signature": '
             '"Zd+PKspUEkrsEyxTmXAwrX3pgfS45Sg35dhMo5Oi0aoI8LoLs3dlyPS9vEXw80fxKyduAl5ws8D0Fu2mXLy9bA=="}'),


### PR DESCRIPTION
The only functional change is a support for `customerCode` in a response to `payment/init` call (an optional `customExpiry` in the request was already properly handled).

The rest is a documentation update, adding a test case and increasing the version number.